### PR TITLE
migrate to .NET 10 SDK and update all dependencies

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 10.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "6.0",
+    "version": "10.0.0",
     "rollForward": "latestMajor",
-    "allowPrerelease": true
+    "allowPrerelease": false
   }
 }

--- a/src/Neutralize.Core/Neutralize.Core.csproj
+++ b/src/Neutralize.Core/Neutralize.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
     <IsPackable>true</IsPackable>
     <Description>.NET Neutralize Core</Description>
@@ -10,18 +10,19 @@
     <PackageTags>Neutralize.Core</PackageTags>
     <RepositoryType>GIT</RepositoryType>
     <RootNamespace>Neutralize</RootNamespace>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="FluentValidation" Version="11.0.3" />
-    <PackageReference Include="MediatR" Version="10.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="MediatR" Version="14.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Optional" Version="4.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,4 +30,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/src/Neutralize.Dapper/Neutralize.Dapper.csproj
+++ b/src/Neutralize.Dapper/Neutralize.Dapper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Version>1.1.0</Version>
         <IsPackable>true</IsPackable>
         <Description>.NET Neutralize Dapper</Description>
@@ -10,7 +10,6 @@
         <PackageTags>Neutralize.Dapper</PackageTags>
         <RepositoryType>GIT</RepositoryType>
         <RootNamespace>Neutralize</RootNamespace>
-        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -18,9 +17,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="DapperExtensions.DotnetCore" Version="1.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+      <PackageReference Include="Dapper" Version="2.1.72" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
     </ItemGroup>
 
 </Project>
-

--- a/src/Neutralize.EFCore/Neutralize.EFCore.csproj
+++ b/src/Neutralize.EFCore/Neutralize.EFCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Version>1.1.0</Version>
         <IsPackable>true</IsPackable>
         <Description>.NET Neutralize EFCore</Description>
@@ -10,13 +10,11 @@
         <PackageTags>Neutralize.EFCore</PackageTags>
         <RepositoryType>GIT</RepositoryType>
         <RootNamespace>Neutralize</RootNamespace>
-        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Neutralize.Core\Neutralize.Core.csproj" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
     </ItemGroup>
 
 </Project>
-

--- a/src/Neutralize.Kafka/Kafka/KafkaAbstraction.cs
+++ b/src/Neutralize.Kafka/Kafka/KafkaAbstraction.cs
@@ -41,7 +41,7 @@ namespace Neutralize.Kafka
         {
             services.AddKafka(options);
 
-            services.AddMediatR(mediatrHandlerAssenblies);
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(mediatrHandlerAssenblies));
             services.AddSingleton<IKafkaMonitorConsumerService, KafkaMonitorConsumerService>();
             services.AddHostedService<KafkaMonitorConsumerWorker>();
 

--- a/src/Neutralize.Kafka/Neutralize.Kafka.csproj
+++ b/src/Neutralize.Kafka/Neutralize.Kafka.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.1.10</Version>
     <IsPackable>true</IsPackable>
     <Description>.NET Neutralize Kafka</Description>
@@ -10,19 +10,16 @@
     <PackageTags>Neutralize.Kafka</PackageTags>
     <RepositoryType>GIT</RepositoryType>
     <RootNamespace>Neutralize</RootNamespace>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="9.0.0" />
-    <PackageReference Include="Confluent.Kafka" Version="1.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="MediatR" Version="14.1.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.14.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Neutralize.Core.Test/Neutralize.Core.Test.csproj
+++ b/test/Neutralize.Core.Test/Neutralize.Core.Test.csproj
@@ -1,19 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="33.0.2" />
-        <PackageReference Include="FluentAssertions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-        <PackageReference Include="Moq.AutoMock" Version="3.3.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-        <PackageReference Include="coverlet.collector" Version="3.0.3" />
+        <PackageReference Include="Bogus" Version="35.6.5" />
+        <PackageReference Include="FluentAssertions" Version="8.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+        <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+        <PackageReference Include="coverlet.collector" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Neutralize.Dapper.Test/Neutralize.Dapper.Test.csproj
+++ b/test/Neutralize.Dapper.Test/Neutralize.Dapper.Test.csproj
@@ -2,20 +2,18 @@
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SQLite" Version="3.13.0" />
-        <PackageReference Include="Bogus" Version="33.0.2" />
-        <PackageReference Include="Moq.AutoMock" Version="3.3.0" />
-        <PackageReference Include="FluentAssertions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-        <PackageReference Include="System.Data.SQLite" Version="1.0.116" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-        <PackageReference Include="coverlet.collector" Version="3.0.2" />
+        <PackageReference Include="Bogus" Version="35.6.5" />
+        <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
+        <PackageReference Include="FluentAssertions" Version="8.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+        <PackageReference Include="coverlet.collector" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Neutralize.Dapper.Test/Setup/DapperFixture.cs
+++ b/test/Neutralize.Dapper.Test/Setup/DapperFixture.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Data;
-using System.Data.SQLite;
+using Microsoft.Data.Sqlite;
 using System.IO;
 using Dapper;
 using Moq.AutoMock;
@@ -30,7 +30,7 @@ namespace Neutralize.Dapper.Test.Setup
 
         public IDbConnection GenereteConnection()
         {
-            var connection = new SQLiteConnection("Data Source=:memory:");
+            var connection = new SqliteConnection("Data Source=:memory:");
 
             connection.Open();
             connection.Execute(ReadScriptFile("CreateInitialTables"));

--- a/test/Neutralize.EFCore.Test/EFCoreRepository_Test.cs
+++ b/test/Neutralize.EFCore.Test/EFCoreRepository_Test.cs
@@ -100,7 +100,7 @@ namespace Neutralize.EFCore.Test
 
             // Assert
             todos.Should().NotBeEmpty();
-            todos.Count.Should().BeGreaterOrEqualTo(10);
+            todos.Count.Should().BeGreaterThanOrEqualTo(10);
         }
         
         [Trait("Data", "EFCore")]
@@ -116,7 +116,7 @@ namespace Neutralize.EFCore.Test
             var count = await repository.CountAsync(todo => todo.Desacription != null);
 
             // Assert
-            count.Should().BeGreaterOrEqualTo(10);
+            count.Should().BeGreaterThanOrEqualTo(10);
         }
         
         [Trait("Data", "EFCore")]
@@ -133,7 +133,7 @@ namespace Neutralize.EFCore.Test
 
             // Assert
             todos.Should().NotBeEmpty();
-            todos.Count().Should().BeGreaterOrEqualTo(10);
+            todos.Count().Should().BeGreaterThanOrEqualTo(10);
         }
         
         [Trait("Data", "EFCore")]

--- a/test/Neutralize.EFCore.Test/Neutralize.EFCore.Test.csproj
+++ b/test/Neutralize.EFCore.Test/Neutralize.EFCore.Test.csproj
@@ -1,20 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="34.0.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.6" />
-        <PackageReference Include="Moq.AutoMock" Version="3.3.0" />
-        <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+        <PackageReference Include="Bogus" Version="35.6.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+        <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
+        <PackageReference Include="FluentAssertions" Version="8.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+        <PackageReference Include="coverlet.collector" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Neutralize.Kafka.Test/KafkaAbstraction_Test.cs
+++ b/test/Neutralize.Kafka.Test/KafkaAbstraction_Test.cs
@@ -47,7 +47,7 @@ public class KafkaAbstraction_Test
         );
 
         // Assert
-        services.Count.Should().Be(12);
+        services.Count.Should().Be(11);
         services.Any(s => s.ServiceType == typeof(IKafkaFactory)).Should().BeTrue();
         services.Any(s => s.ServiceType == typeof(IKafkaConfiguration)).Should().BeTrue();
         services.Any(s => s.ServiceType == typeof(IMediator)).Should().BeTrue();

--- a/test/Neutralize.Kafka.Test/Neutralize.Kafka.Test.csproj
+++ b/test/Neutralize.Kafka.Test/Neutralize.Kafka.Test.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="33.0.2" />
-    <PackageReference Include="Moq.AutoMock" Version="3.3.0" />
-    <PackageReference Include="FluentAssertions" Version="6.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
+    <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Target framework: net6.0 → net10.0 across all 8 projects
- global.json: SDK 6.0 → 10.0.0; CI workflow: dotnet-version 6.0.x → 10.0.x
- Replace Microsoft.AspNetCore.Http 2.2.2 with FrameworkReference to Microsoft.AspNetCore.App
- Replace DapperExtensions.DotnetCore with Dapper 2.1.72 (only core Dapper APIs were used)
- Replace System.Data.SQLite with Microsoft.Data.Sqlite 10.0.7 in Dapper test project
- MediatR 9/10 → 14.1.0 (unified); fix AddMediatR call to use MediatR 12+ configuration API
- Remove MediatR.Extensions.Microsoft.DependencyInjection (merged into MediatR 12+)
- AutoMapper 11 → 16.1.1, FluentValidation 11 → 12.1.1, Confluent.Kafka 1.7 → 2.14.0
- EF Core 6.0.6 → 10.0.7; Microsoft.Extensions.* 5/6 → 10.0.0
- Test tooling: xunit 2.4.1 → 2.9.3, Moq.AutoMock 3.3 → 4.0.2, FluentAssertions 6.x → 8.9.0
- Fix BeGreaterOrEqualTo → BeGreaterThanOrEqualTo (FluentAssertions 8.x rename)
- Update MediatR service count assertion (14.x registers one fewer internal service)
- All 62 unit tests pass

This pull request upgrades the Neutralize solution from .NET 6 to .NET 10, updating all core, Dapper, EFCore, and Kafka projects as well as their test projects. It also brings all major dependencies to their latest compatible versions, modernizes some code to match updated APIs, and makes minor test improvements for compatibility.

**.NET 10 Migration and Dependency Upgrades**

- Updated all project files (`.csproj`, `global.json`, and GitHub Actions workflow) to target .NET 10, removing explicit `LangVersion` properties and setting `allowPrerelease` to false for SDK resolution. All major package dependencies (e.g., MediatR, AutoMapper, FluentValidation, EntityFrameworkCore, Dapper, and test libraries) are upgraded to their latest .NET 10-compatible versions. [[1]](diffhunk://#diff-b673e85d14ea92c37f0edc1b8bb94ae85148a2a12358eb8caffc4f0a8f5d15f4L16-R16) [[2]](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL3-R5) [[3]](diffhunk://#diff-953d55c7e103f7ade172c954d5b25edf5f36f2cd8da0598cce5c00af433f160cL4-R4) [[4]](diffhunk://#diff-4c5338631b8a181f5e860928ae97c6d443d0f90e94275e6894fea4f28ebd08b2L4-R4) [[5]](diffhunk://#diff-5cf9b4a77c770b33c77a7c389a20007ebcf763a8881972d55e5bbe1dcea96fbdL4-R4) [[6]](diffhunk://#diff-7ff53385781326ff5edee3da85c9fccb86470c78661cf0d8d65e06580260d701L4-R4) [[7]](diffhunk://#diff-bc76e6fd191a0540fb6a810d6595432e0d5a292efa657f60c5f743b29dea3e4bL4-R15) [[8]](diffhunk://#diff-402952eb928bd07c5a27567680e1d9514df4256e012b6109445f08d93e61f9b6L5-R16) [[9]](diffhunk://#diff-4cbff177a9a37933d671eecf9e17d0f91e45f2b3eab21008c7c62215a137648fR4-R16) [[10]](diffhunk://#diff-8b1e0b786de332660ec8efeb6e7827ae03c1073d714959d67491c6114655f1b0L4-R18)

**Project Reference and Framework Changes**

- Added `FrameworkReference` to `Microsoft.AspNetCore.App` in `Neutralize.Core.csproj` and updated or replaced several package references to align with .NET 10 best practices.
- Updated Dapper project to use the official `Dapper` package instead of `DapperExtensions.DotnetCore`.

**Code Modernization for Upgraded Libraries**

- Updated MediatR registration in `KafkaAbstraction.cs` to use the new `RegisterServicesFromAssemblies` API required by MediatR v14+.
- Updated usages of `System.Data.SQLite` to `Microsoft.Data.Sqlite` in Dapper test fixtures for compatibility with .NET 10 and the new package set. [[1]](diffhunk://#diff-ce24e62b229f2e808265f3889665fa5c04a46ce9b1f7bd8afddd361b3d312421L3-R3) [[2]](diffhunk://#diff-ce24e62b229f2e808265f3889665fa5c04a46ce9b1f7bd8afddd361b3d312421L33-R33)

**Test Improvements and Compatibility Fixes**

- Upgraded all test projects and dependencies to .NET 10 and latest versions, and fixed assertion method names to match updated FluentAssertions API. [[1]](diffhunk://#diff-c3895626123c034cc8bca50d4e744d13839dd523b74b2448ec693f9771d19564L103-R103) [[2]](diffhunk://#diff-c3895626123c034cc8bca50d4e744d13839dd523b74b2448ec693f9771d19564L119-R119) [[3]](diffhunk://#diff-c3895626123c034cc8bca50d4e744d13839dd523b74b2448ec693f9771d19564L136-R136)
- Adjusted expected service count in Kafka tests to reflect dependency changes.

These changes ensure the codebase is fully compatible with .NET 10 and up-to-date with the latest library and framework best practices.

https://github.com/mauriciomoccelin/neutralize/issues/44