### PR TITLE
chore: generate new .net version

### DIFF
--- a/build/configuration.json
+++ b/build/configuration.json
@@ -1,18 +1,18 @@
 [
     {
         "path": "src/Neutralize.Core/Neutralize.Core.csproj",
-        "version": "6.2.5"
+        "version": "10.0.0"
     },
     {
         "path": "src/Neutralize.Dapper/Neutralize.Dapper.csproj",
-        "version": "6.2.5"
+        "version": "10.0.0"
     },
     {
         "path": "src/Neutralize.EFCore/Neutralize.EFCore.csproj",
-        "version": "6.2.5"
+        "version": "10.0.0"
     },
     {
         "path": "src/Neutralize.Kafka/Neutralize.Kafka.csproj",
-        "version": "6.2.5"
+        "version": "10.0.0"
     }
 ]


### PR DESCRIPTION
This pull request updates the project version numbers in the build configuration to align all core `Neutralize` components with the new major release.

Version updates:

* Updated the version for `Neutralize.Core.csproj`, `Neutralize.Dapper.csproj`, `Neutralize.EFCore.csproj`, and `Neutralize.Kafka.csproj` from `6.2.5` to `10.0.0` in `build/configuration.json`.